### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,9 +12,9 @@ Seven_Segment_Pixel	KEYWORD1
 
 updateDigit	KEYWORD2
 updateDelimiter	KEYWORD2
-show			KEYWORD2
-begin			KEYWORD2
-setPixelColor   KEYWORD2
+show	KEYWORD2
+begin	KEYWORD2
+setPixelColor	KEYWORD2
 
 #######################################
 # Constants 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords